### PR TITLE
Add atuin shell history sync server with Tailscale ingress

### DIFF
--- a/apps/atuin/cluster.yaml
+++ b/apps/atuin/cluster.yaml
@@ -1,0 +1,21 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: atuin-database
+spec:
+  instances: 1
+  storage:
+    size: 5Gi
+    pvcTemplate:
+      accessModes:
+      - ReadWriteOnce
+      storageClassName: nas1-mtank-iscsi
+      resources:
+        requests:
+          storage: 5Gi
+  bootstrap:
+    initdb:
+      database: atuin
+      owner: atuin
+      secret:
+        name: onepassword-atuin-database

--- a/apps/atuin/deployment.yaml
+++ b/apps/atuin/deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: atuin
+spec:
+  selector:
+    matchLabels:
+      app: atuin
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: atuin
+    spec:
+      containers:
+      - name: atuin
+        image: ghcr.io/atuinsh/atuin:v18.6.1
+        args:
+        - server
+        - start
+        env:
+        - name: ATUIN_HOST
+          value: "0.0.0.0"
+        - name: ATUIN_PORT
+          value: "8888"
+        - name: ATUIN_OPEN_REGISTRATION
+          value: "false"
+        - name: ATUIN_PATH
+          value: /data
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: onepassword-atuin-database
+              key: password
+        - name: ATUIN_DB_URI
+          value: "postgresql://atuin:$(DB_PASSWORD)@atuin-database-rw.atuin.svc.cluster.local/atuin"
+        ports:
+        - name: http
+          containerPort: 8888
+        livenessProbe:
+          tcpSocket:
+            port: 8888
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          failureThreshold: 3
+        volumeMounts:
+        - name: data
+          mountPath: /data
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: data

--- a/apps/atuin/ingress-tailscale.yaml
+++ b/apps/atuin/ingress-tailscale.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: atuin-tailscale
+  annotations:
+    tailscale.com/proxy-group: heimdall
+    tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
+spec:
+  tls:
+  - hosts:
+    - atuin
+  defaultBackend:
+    service:
+      name: atuin
+      port:
+        name: http
+  ingressClassName: tailscale

--- a/apps/atuin/onepassword-item.yaml
+++ b/apps/atuin/onepassword-item.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/onepassword.com/onepassworditem_v1.json
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: onepassword-atuin-database
+spec:
+  itemPath: "vaults/copxopw5gkuo2m3cv7acvkrfxy/items/atuin-database"

--- a/apps/atuin/pvc-data.yaml
+++ b/apps/atuin/pvc-data.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data
+spec:
+  storageClassName: nas1-mtank-iscsi
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/apps/atuin/service.yaml
+++ b/apps/atuin/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: atuin
+spec:
+  selector:
+    app: atuin
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8888


### PR DESCRIPTION
Deploys the atuin server to the atuin namespace with:
- CloudNative PG PostgreSQL cluster (5Gi, nas1-mtank-iscsi)
- 5Gi PVC for the record store (nas1-mtank-iscsi)
- DB credentials via 1Password (vaults/copxopw5gkuo2m3cv7acvkrfxy/items/atuin-database)
- Tailscale ingress via the heimdall proxy-group, hostname: atuin

https://claude.ai/code/session_01TsvKEcTnqp2tyG2CxcBaN3