### PR TITLE
Add atuin shell history sync server

### DIFF
--- a/apps/atuin/deployment.yaml
+++ b/apps/atuin/deployment.yaml
@@ -25,7 +25,9 @@ spec:
         - name: ATUIN_PORT
           value: "8888"
         - name: ATUIN_OPEN_REGISTRATION
-          value: "false"
+          value: "true"
+        - name: RUST_LOG
+          value: debug
         - name: ATUIN_PATH
           value: /data
         - name: DB_PASSWORD


### PR DESCRIPTION
## Summary

- Deploys the [atuin](https://github.com/atuinsh/atuin) shell history sync server to the `atuin` namespace
- CloudNative PG single-instance PostgreSQL cluster (5Gi, `nas1-mtank-iscsi`)
- 5Gi PVC for the record store (`nas1-mtank-iscsi`)
- Tailscale ingress via the `heimdall` proxy-group, reachable at `https://atuin` on the tailnet
- Open registration and debug logging enabled

## Prerequisites

Create a 1Password item named `atuin-database` in vault `copxopw5gkuo2m3cv7acvkrfxy` with:
- `username`: `atuin`
- `password`: (your chosen password)

## Test plan

- [ ] ArgoCD syncs `atuin` namespace successfully
- [ ] CloudNative PG cluster reaches `Healthy` state
- [ ] Deployment pod reaches `Running`
- [ ] `atuin register` works against `https://atuin.<tailnet>.ts.net`
- [ ] `atuin sync` pushes/pulls history successfully

https://claude.ai/code/session_01TsvKEcTnqp2tyG2CxcBaN3

---
_Generated by [Claude Code](https://claude.ai/code/session_01TsvKEcTnqp2tyG2CxcBaN3)_