### PR TITLE
fix heimdall ProxyClass port format for Tailscale operator

### DIFF
--- a/apps-helm/tailscale-operator/manifests/heimdall-proxyclass.yaml
+++ b/apps-helm/tailscale-operator/manifests/heimdall-proxyclass.yaml
@@ -7,7 +7,6 @@ spec:
   staticEndpoints:
     nodePort:
       ports:
-      - port: 31667
-        endPort: 31680
+      - "31667-31680"
       selector:
         kubernetes.io/os: linux


### PR DESCRIPTION
## Problem

The `heimdall-proxyclass.yaml` used an invalid `port`/`endPort` object format for `staticEndpoints.nodePort.ports`, which the Tailscale operator does not accept.

## Fix

Changed to the string range format expected by the Tailscale ProxyClass API (v1.86+):

```yaml
ports:
- "31667-31680"
```

Matches the official [Tailscale docs](https://tailscale.com/docs/kubernetes-operator/manage-and-configure/configure-static-endpoints).

---
*Co-authored with [Pi](https://pi.dev) (Qwen3.6-35B-A3B-MLX-8bit)*